### PR TITLE
Make message payload optional

### DIFF
--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -15,12 +15,20 @@ module Webpush
   TEMP_GCM_URL = 'https://gcm-http.googleapis.com/gcm'
 
   class << self
-    def payload_send(message:, endpoint:, p256dh:, auth:, **options)
+    def payload_send(endpoint:, message: "", p256dh: "", auth: "", **options)
       endpoint = endpoint.gsub(GCM_URL, TEMP_GCM_URL)
 
-      payload = Webpush::Encryption.encrypt(message, p256dh, auth)
+      payload = build_payload(message, p256dh, auth)
 
       Webpush::Request.new(endpoint, payload, options).perform
+    end
+
+    private
+
+    def build_payload(message, p256dh, auth)
+      return {} if message.nil? || message.empty?
+
+      Webpush::Encryption.encrypt(message, p256dh, auth)
     end
   end
 end

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -19,32 +19,8 @@ module Webpush
       endpoint = endpoint.gsub(GCM_URL, TEMP_GCM_URL)
 
       payload = Webpush::Encryption.encrypt(message, p256dh, auth)
-      # push_server_post(endpoint, payload, api_key)
 
       Webpush::Request.new(endpoint, payload, options).perform
-    end
-
-    private
-
-    def push_server_post(endpoint, payload, api_key = "")
-      uri = URI.parse(endpoint)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      header = {
-          "Content-Type" => "application/octet-stream",
-          "Content-Encoding" => "aesgcm",
-          "Encryption" => "salt=#{Base64.urlsafe_encode64(payload[:salt]).delete('=')}",
-          "Crypto-Key" => "dh=#{Base64.urlsafe_encode64(payload[:server_public_key_bn]).delete('=')}",
-          "Ttl"        => "2419200"
-      }
-      header["Authorization"] = "key=#{api_key}" unless api_key.nil? || api_key.empty?
-      req = Net::HTTP::Post.new(uri.request_uri, header)
-      req.body = payload[:ciphertext]
-      res = http.request(req)
-      res.code == "201"
-    rescue
-      false
     end
   end
 end

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -15,6 +15,17 @@ module Webpush
   TEMP_GCM_URL = 'https://gcm-http.googleapis.com/gcm'
 
   class << self
+    # Deliver the payload to the required endpoint given by the JavaScript
+    # PushSubscription. Including an optional message requires p256dh and
+    # auth keys from the PushSubscription.
+    #
+    # @param endpoint [String] the required PushSubscription url
+    # @param message [String] the optional payload
+    # @param p256dh [String] the user's public ECDH key given by the PushSubscription
+    # @param auth [String] the user's private ECDH key given by the PushSubscription
+    # @param options [Hash<Symbol,String>] additional options for the notification
+    # @option options [String] :api_key required for Google, omit for Firefox
+    # @option options [#to_s] :ttl Time-to-live in seconds
     def payload_send(endpoint:, message: "", p256dh: "", auth: "", **options)
       endpoint = endpoint.gsub(GCM_URL, TEMP_GCM_URL)
 

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -6,6 +6,7 @@ require 'json'
 
 require 'webpush/version'
 require 'webpush/encryption'
+require 'webpush/request'
 
 module Webpush
 
@@ -14,11 +15,13 @@ module Webpush
   TEMP_GCM_URL = 'https://gcm-http.googleapis.com/gcm'
 
   class << self
-    def payload_send(message:, endpoint:, p256dh:, auth:, api_key: "")
+    def payload_send(message:, endpoint:, p256dh:, auth:, **options)
       endpoint = endpoint.gsub(GCM_URL, TEMP_GCM_URL)
 
       payload = Webpush::Encryption.encrypt(message, p256dh, auth)
-      push_server_post(endpoint, payload, api_key)
+      # push_server_post(endpoint, payload, api_key)
+
+      Webpush::Request.new(endpoint, payload, options).perform
     end
 
     private

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -20,7 +20,7 @@ module Webpush
 
       payload = build_payload(message, p256dh, auth)
 
-      Webpush::Request.new(endpoint, payload, options).perform
+      Webpush::Request.new(endpoint, options.merge(payload: payload)).perform
     end
 
     private

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -1,6 +1,6 @@
 module Webpush
   class Request
-    def initialize(endpoint, options)
+    def initialize(endpoint, options = {})
       @endpoint = endpoint
       @options = default_options.merge(options)
       @payload = @options.delete(:payload) || {}
@@ -18,8 +18,6 @@ module Webpush
     rescue
       false
     end
-
-    private
 
     def headers
       headers = {}
@@ -41,12 +39,14 @@ module Webpush
       @payload.fetch(:ciphertext, "")
     end
 
+    private
+
     def ttl
-      @options[:ttl].to_s
+      @options.fetch(:ttl).to_s
     end
 
     def api_key
-      @options[:api_key]
+      @options.fetch(:api_key, nil)
     end
 
     def api_key?
@@ -68,8 +68,7 @@ module Webpush
     def default_options
       {
         api_key: nil,
-        ttl: 60*60*24*7*4,        # 4 weeks
-        raise_exceptions: false
+        ttl: 60*60*24*7*4 # 4 weeks
       }
     end
   end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -1,0 +1,77 @@
+module Webpush
+  class Request
+    def initialize(endpoint, payload, options)
+      @endpoint = endpoint
+      @payload = payload
+
+      @options = default_options.merge(options)
+    end
+
+    def perform
+      uri = URI.parse(@endpoint)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      req = Net::HTTP::Post.new(uri.request_uri, request_headers)
+      req.body = request_body
+      res = http.request(req)
+      res.code == "201"
+    rescue StandardError => e
+      false
+    end
+
+    private
+
+    def request_body
+      @payload.fetch(:ciphertext, "")
+    end
+
+    def ttl
+      @options[:ttl].to_s
+    end
+
+    def api_key
+      @options[:api_key]
+    end
+
+    def api_key?
+      !(api_key.nil? || api_key.empty?)
+    end
+
+    def encrypted_payload?
+      [:ciphertext, :server_public_key_bn, :salt].all? { |key| @payload.has_key?(key) }
+    end
+
+    def request_headers
+      headers = {}
+      headers["Content-Type"] = "application/octet-stream"
+      headers["Ttl"]          = ttl
+
+      if encrypted_payload?
+        headers["Content-Encoding"] = "aesgcm"
+        headers["Encryption"] = "salt=#{salt_param}"
+        headers["Crypto-Key"] = "dh=#{dh_param}"
+      end
+
+      headers["Authorization"] = "key=#{api_key}" if api_key?
+
+      headers
+    end
+
+    def dh_param
+      Base64.urlsafe_encode64(@payload.fetch(:server_public_key_bn)).delete('=')
+    end
+
+    def salt_param
+      Base64.urlsafe_encode64(@payload.fetch(:salt)).delete('=')
+    end
+
+    def default_options
+      {
+        api_key: nil,
+        ttl: 60*60*24*7*4,        # 4 weeks
+        raise_exceptions: false
+      }
+    end
+  end
+end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -16,7 +16,7 @@ module Webpush
       req.body = request_body
       res = http.request(req)
       res.code == "201"
-    rescue StandardError => e
+    rescue
       false
     end
 

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Webpush::Request do
+  describe '#headers' do
+    let(:request) { Webpush::Request.new("endpoint") }
+
+    it { expect(request.headers['Content-Type']).to eq('application/octet-stream') }
+    it { expect(request.headers['Ttl']).to eq('2419200') }
+
+    it 'inserts encryption headers for valid payload' do
+      payload = {
+        ciphertext: "ciphertext",
+        server_public_key_bn:
+        "server_public_key_bn",
+        salt: "salt"
+      }
+      request = Webpush::Request.new("endpoint", payload: payload)
+
+      expect(request.headers['Content-Encoding']).to eq("aesgcm")
+      expect(request.headers['Encryption']).to eq("salt=c2FsdA")
+      expect(request.headers['Crypto-Key']).to eq("dh=c2VydmVyX3B1YmxpY19rZXlfYm4")
+    end
+
+    it 'inserts Authorization header when api_key present' do
+      request = Webpush::Request.new("endpoint", api_key: "api_key")
+
+      expect(request.headers['Authorization']).to eq("key=api_key")
+    end
+
+    it 'does not insert Authorization header when api_key blank' do
+      request = Webpush::Request.new("endpoint", api_key: nil)
+
+      expect(request.headers['Authorization']).to be_nil
+
+      request = Webpush::Request.new("endpoint", api_key: "")
+
+      expect(request.headers['Authorization']).to be_nil
+
+      request = Webpush::Request.new("endpoint")
+
+      expect(request.headers['Authorization']).to be_nil
+    end
+  end
+end

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -7,38 +7,56 @@ describe Webpush::Request do
     it { expect(request.headers['Content-Type']).to eq('application/octet-stream') }
     it { expect(request.headers['Ttl']).to eq('2419200') }
 
-    it 'inserts encryption headers for valid payload' do
-      payload = {
-        ciphertext: "ciphertext",
-        server_public_key_bn:
-        "server_public_key_bn",
-        salt: "salt"
-      }
-      request = Webpush::Request.new("endpoint", payload: payload)
+    describe 'from :payload' do
+      it 'inserts encryption headers for valid payload' do
+        payload = {
+          ciphertext: "ciphertext",
+          server_public_key_bn:
+          "server_public_key_bn",
+          salt: "salt"
+        }
+        request = Webpush::Request.new("endpoint", payload: payload)
 
-      expect(request.headers['Content-Encoding']).to eq("aesgcm")
-      expect(request.headers['Encryption']).to eq("salt=c2FsdA")
-      expect(request.headers['Crypto-Key']).to eq("dh=c2VydmVyX3B1YmxpY19rZXlfYm4")
+        expect(request.headers['Content-Encoding']).to eq("aesgcm")
+        expect(request.headers['Encryption']).to eq("salt=c2FsdA")
+        expect(request.headers['Crypto-Key']).to eq("dh=c2VydmVyX3B1YmxpY19rZXlfYm4")
+      end
     end
 
-    it 'inserts Authorization header when api_key present' do
-      request = Webpush::Request.new("endpoint", api_key: "api_key")
+    describe 'from :api_key' do
+      it 'inserts Authorization header when api_key present' do
+        request = Webpush::Request.new("endpoint", api_key: "api_key")
 
-      expect(request.headers['Authorization']).to eq("key=api_key")
+        expect(request.headers['Authorization']).to eq("key=api_key")
+      end
+
+      it 'does not insert Authorization header when api_key blank' do
+        request = Webpush::Request.new("endpoint", api_key: nil)
+
+        expect(request.headers['Authorization']).to be_nil
+
+        request = Webpush::Request.new("endpoint", api_key: "")
+
+        expect(request.headers['Authorization']).to be_nil
+
+        request = Webpush::Request.new("endpoint")
+
+        expect(request.headers['Authorization']).to be_nil
+      end
     end
 
-    it 'does not insert Authorization header when api_key blank' do
-      request = Webpush::Request.new("endpoint", api_key: nil)
+    describe 'from :ttl' do
+      it 'can override Ttl with :ttl option with string' do
+        request = Webpush::Request.new("endpoint", ttl: '300')
 
-      expect(request.headers['Authorization']).to be_nil
+        expect(request.headers['Ttl']).to eq('300')
+      end
 
-      request = Webpush::Request.new("endpoint", api_key: "")
+      it 'can override Ttl with :ttl option with fixnum' do
+        request = Webpush::Request.new("endpoint", ttl: 60 * 5)
 
-      expect(request.headers['Authorization']).to be_nil
-
-      request = Webpush::Request.new("endpoint")
-
-      expect(request.headers['Authorization']).to be_nil
+        expect(request.headers['Ttl']).to eq('300')
+      end
     end
   end
 end

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -59,4 +59,24 @@ describe Webpush::Request do
       end
     end
   end
+
+  describe '#body' do
+    it 'extracts :ciphertext from the :payload argument' do
+      request = Webpush::Request.new('endpoint', payload: { ciphertext: 'encrypted' })
+
+      expect(request.body).to eq('encrypted')
+    end
+
+    it 'is empty string when no :ciphertext' do
+      request = Webpush::Request.new('endpoint', payload: {})
+
+      expect(request.body).to eq('')
+    end
+
+    it 'is empty string when no :payload' do
+      request = Webpush::Request.new('endpoint')
+
+      expect(request.body).to eq('')
+    end
+  end
 end

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -61,26 +61,6 @@ describe Webpush do
       expect(result).to be(false)
     end
 
-    it 'inserts Authorization header when present' do
-      api_key = SecureRandom.hex(16)
-      expected_headers.merge!('Authorization' => "key=#{api_key}")
-
-      stub_request(:post, expected_endpoint).
-        with(body: expected_body, headers: expected_headers).
-        to_return(status: 201, body: "", headers: {})
-
-      Webpush.payload_send(message: message, endpoint: endpoint, p256dh: p256dh, auth: auth, api_key: api_key)
-    end
-
-    it 'does not insert Authorization header when blank' do
-      stub_request(:post, expected_endpoint).
-        with(body: expected_body, headers: expected_headers).
-        to_return(status: 201, body: "", headers: {})
-
-      Webpush.payload_send(message: message, endpoint: endpoint, p256dh: p256dh, auth: auth, api_key: "")
-      Webpush.payload_send(message: message, endpoint: endpoint, p256dh: p256dh, auth: auth, api_key: nil)
-    end
-
     it 'message and encryption keys are optional' do
       expect(Webpush::Encryption).to_not receive(:encrypt)
 

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -80,6 +80,20 @@ describe Webpush do
       Webpush.payload_send(message: message, endpoint: endpoint, p256dh: p256dh, auth: auth, api_key: "")
       Webpush.payload_send(message: message, endpoint: endpoint, p256dh: p256dh, auth: auth, api_key: nil)
     end
+
+    it 'message and encryption keys are optional' do
+      expect(Webpush::Encryption).to_not receive(:encrypt)
+
+      expected_headers.delete('Crypto-Key')
+      expected_headers.delete('Content-Encoding')
+      expected_headers.delete('Encryption')
+
+      stub_request(:post, expected_endpoint).
+        with(body: nil, headers: expected_headers).
+        to_return(status: 201, body: "", headers: {})
+
+      Webpush.payload_send(endpoint: endpoint)
+    end
   end
 
   context 'chrome endpoint' do


### PR DESCRIPTION
Looks like the only required parameter for Google/Firefox to push a notification is the `endpoint`. This pull request extracts a `Request` class to represent the logic for assembling the `net/http` request with the optional payload.

I've also provided an additional parameter, `:ttl`, as a way to change the time-to-live header.