### PR TITLE
Make the response more detailed.

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -13,10 +13,9 @@ module Webpush
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       req = Net::HTTP::Post.new(uri.request_uri, headers)
       req.body = body
-      res = http.request(req)
-      res.code == "201"
-    rescue
-      false
+      http.request(req)
+    rescue => e
+      raise e
     end
 
     def headers


### PR DESCRIPTION
1. Update `request#perform` to let it return the raw http response, or raise an
exception when unexpected error happened.
2. Update the `webpush_spec` to make the tests pass.