### PR TITLE
Option to specify a cert store

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -1,14 +1,4 @@
 module Webpush
-  @@cert_store = nil
-  
-  def self.cert_store= cs
-    @@cert_store = cs
-  end
-
-  def self.cert_store
-    @@cert_store
-  end
-  
   class Request
     def initialize(endpoint, options = {})
       @endpoint = endpoint
@@ -20,8 +10,8 @@ module Webpush
       uri = URI.parse(@endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      if Webpush.cert_store
-        http.cert_store = Webpush.cert_store
+      if @options[:cert_store]
+        http.cert_store = @options[:cert_store]
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       else
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -1,4 +1,14 @@
 module Webpush
+  @@cert_store = nil
+  
+  def self.cert_store= cs
+    @@cert_store = cs
+  end
+
+  def self.cert_store
+    @@cert_store
+  end
+  
   class Request
     def initialize(endpoint, options = {})
       @endpoint = endpoint
@@ -10,7 +20,12 @@ module Webpush
       uri = URI.parse(@endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if Webpush.cert_store
+        http.cert_store = Webpush.cert_store
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      else
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
       req = Net::HTTP::Post.new(uri.request_uri, headers)
       req.body = body
       http.request(req)


### PR DESCRIPTION
Having the verify mode be OpenSSL::SSL::VERIFY_NONE is unsafe, I propose giving the user the option to specify  a cert_store and use OpenSSL::SSL::VERIFY_PEER.