### PR TITLE
Don't include API key for firefox or other browsers

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -49,7 +49,7 @@ module Webpush
     end
 
     def api_key?
-      !(api_key.nil? || api_key.empty?)
+      !(api_key.nil? || api_key.empty?) && @endpoint =~ /\Ahttps:\/\/.+\.googleapis\.com/
     end
 
     def encrypted_payload?

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -24,10 +24,16 @@ describe Webpush::Request do
     end
 
     describe 'from :api_key' do
-      it 'inserts Authorization header when api_key present' do
-        request = Webpush::Request.new("endpoint", api_key: "api_key")
+      it 'inserts Authorization header when api_key present, and endpoint is for Chrome' do
+        request = Webpush::Request.new('https://gcm-http.googleapis.com/gcm/xyz', api_key: "api_key")
 
         expect(request.headers['Authorization']).to eq("key=api_key")
+      end
+
+      it 'does not insert Authorization header when endpoint is not for Chrome, even if api_key is present' do
+        request = Webpush::Request.new('https://some.random.endpoint.com/xyz', api_key: "api_key")
+
+        expect(request.headers['Authorization']).to be_nil
       end
 
       it 'does not insert Authorization header when api_key blank' do


### PR DESCRIPTION
Firefox will fail with a 400 Bad Request if the api key header is included. Instead of having the user have to figure out themselves whether a particular subscription is a Chrome or Firefox subscription, lets do it for them here.