### PR TITLE
detect and handle response errors

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -28,6 +28,8 @@ module Webpush
       elsif !resp.is_a?(Net::HTTPSuccess)  #unknown/unhandled response error
         raise ResponseError.new "host: #{uri.host}, #{resp.inspect}\nbody:\n#{resp.body}"
       end
+
+      resp
     end
 
     def headers

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -1,4 +1,11 @@
 module Webpush
+
+  class ResponseError < RuntimeError
+  end
+
+  class InvalidSubscription < ResponseError
+  end
+
   class Request
     def initialize(endpoint, options = {})
       @endpoint = endpoint
@@ -13,9 +20,14 @@ module Webpush
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       req = Net::HTTP::Post.new(uri.request_uri, headers)
       req.body = body
-      http.request(req)
-    rescue => e
-      raise e
+      resp = http.request(req)
+
+      if resp.is_a?(Net::HTTPGone) ||   #Firefox unsubscribed response
+          (resp.is_a?(Net::HTTPBadRequest) && resp.message == "UnauthorizedRegistration")  #Chrome unsubscribed response
+        raise InvalidSubscription.new(resp.inspect)
+      elsif !resp.is_a?(Net::HTTPSuccess)  #unknown/unhandled response error
+        raise ResponseError.new "host: #{uri.host}, #{resp.inspect}\nbody:\n#{resp.body}"
+      end
     end
 
     def headers

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -43,7 +43,8 @@ describe Webpush do
 
       result = subject
 
-      expect(result).to be_nil
+      expect(result).to be_a(Net::HTTPCreated)
+      expect(result.code).to eql('201')
     end
 
     it 'raises InvalidSubscription if and only if the combination of status code and message indicate an invalid subscription' do


### PR DESCRIPTION
As discussed in https://github.com/zaru/webpush/issues/17: detect when the failure is because the subscription/endpoint is no longer valid and then raise a InvalidSubscription error, and then if the request fails for any other reason a ResponseError error is raised. The only way the method would return without raising an exception is if the request went through. 