### PR TITLE
VERIFY_PEER by default - no need for a cert_store option

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -17,12 +17,6 @@ module Webpush
       uri = URI.parse(@endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      if @options[:cert_store]
-        http.cert_store = @options[:cert_store]
-        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      else
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      end
       req = Net::HTTP::Post.new(uri.request_uri, headers)
       req.body = body
       resp = http.request(req)


### PR DESCRIPTION
Testing all the way back to ruby 2.1.10, the last supported version of ruby still supported, if we don't specify the cert store and leave out the line http.verify_mode = OpenSSL::SSL::VERIFY_NONE, ruby will use its own cert store by default and conduct VERIFY_PEER verification. I can't see any reason why this shouldn't be the default... 

Also, since Ruby's default cert_store is capable of verifying our small set of endpoints, I don't think we need an option to specify a custom cert_store so I've removed that as well