### PR TITLE
api key only needed for old google apis

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -62,7 +62,7 @@ module Webpush
     end
 
     def api_key?
-      !(api_key.nil? || api_key.empty?) && @endpoint =~ /\Ahttps:\/\/.+\.googleapis\.com/
+      !(api_key.nil? || api_key.empty?) && @endpoint =~ /\Ahttps:\/\/(android|gcm-http)\.googleapis\.com/
     end
 
     def encrypted_payload?

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -24,10 +24,16 @@ describe Webpush::Request do
     end
 
     describe 'from :api_key' do
-      it 'inserts Authorization header when api_key present, and endpoint is for Chrome' do
+      it 'inserts Authorization header when api_key present, and endpoint is for Chrome\'s non-standards-compliant GCM endpoints' do
         request = Webpush::Request.new('https://gcm-http.googleapis.com/gcm/xyz', api_key: "api_key")
 
         expect(request.headers['Authorization']).to eq("key=api_key")
+      end
+
+      it 'does not insert Authorization header for Chrome\'s new standards-compliant endpoints, even if api_key is present' do
+        request = Webpush::Request.new('https://fcm.googleapis.com/fcm/send/ABCD1234', api_key: "api_key")
+
+        expect(request.headers['Authorization']).to be_nil
       end
 
       it 'does not insert Authorization header when endpoint is not for Chrome, even if api_key is present' do


### PR DESCRIPTION
The new fcm.googleapis.com endpoint doesn't require an api_key. 

(Right now, this endpoint is only used for VAPID requests, however Google does eventually intend to have non-VAPID requests go to a standard webpush endpoint, I'm assuming its probably going to be this url)