### PR TITLE
Bug fix invalid base64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.2.5
   - 2.3.0
 before_install: gem install bundler -v 1.11.2
 script: "bundle exec rake spec"

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -47,5 +47,19 @@ module Webpush
     def generate_key
       VapidKey.new
     end
+
+    def encode64(bytes)
+      Base64.urlsafe_encode64(bytes)
+    end
+
+    def decode64(str)
+      # For Ruby < 2.3, Base64.urlsafe_decode64 strict decodes and will raise errors if encoded value is not properly padded
+      # Implementation: http://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_decode64
+      if !str.end_with?("=") && str.length % 4 != 0
+        str = str.ljust((str.length + 3) & ~3, "=")
+      end
+
+      Base64.urlsafe_decode64(str)
+    end
   end
 end

--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -13,12 +13,12 @@ module Webpush
       server_public_key_bn = server.public_key.to_bn
 
       group = OpenSSL::PKey::EC::Group.new(group_name)
-      client_public_key_bn = OpenSSL::BN.new(urlsafe_decode64(p256dh), 2)
+      client_public_key_bn = OpenSSL::BN.new(Webpush.decode64(p256dh), 2)
       client_public_key = OpenSSL::PKey::EC::Point.new(group, client_public_key_bn)
 
       shared_secret = server.dh_compute_key(client_public_key)
 
-      client_auth_token = urlsafe_decode64(auth)
+      client_auth_token = Webpush.decode64(auth)
 
       prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: "Content-Encoding: auth\0").next_bytes(32)
 
@@ -89,16 +89,6 @@ module Webpush
 
     def blank?(value)
       value.nil? || value.empty?
-    end
-
-    def urlsafe_decode64(str)
-      # For Ruby < 2.3, Base64.urlsafe_decode64 strict decodes and will raise errors if encoded value is not properly padded
-      # Implementation: http://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_decode64
-      if !str.end_with?("=") && str.length % 4 != 0
-        str = str.ljust((str.length + 3) & ~3, "=")
-      end
-
-      Base64.urlsafe_decode64(str)
     end
   end
 end

--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -13,12 +13,12 @@ module Webpush
       server_public_key_bn = server.public_key.to_bn
 
       group = OpenSSL::PKey::EC::Group.new(group_name)
-      client_public_key_bn = OpenSSL::BN.new(Base64.urlsafe_decode64(p256dh), 2)
+      client_public_key_bn = OpenSSL::BN.new(urlsafe_decode64(p256dh), 2)
       client_public_key = OpenSSL::PKey::EC::Point.new(group, client_public_key_bn)
 
       shared_secret = server.dh_compute_key(client_public_key)
 
-      client_auth_token = Base64.urlsafe_decode64(auth)
+      client_auth_token = urlsafe_decode64(auth)
 
       prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: "Content-Encoding: auth\0").next_bytes(32)
 
@@ -89,6 +89,16 @@ module Webpush
 
     def blank?(value)
       value.nil? || value.empty?
+    end
+
+    def urlsafe_decode64(str)
+      # For Ruby < 2.3, Base64.urlsafe_decode64 strict decodes and will raise errors if encoded value is not properly padded
+      # Implementation: http://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_decode64
+      if !str.end_with?("=") && str.length % 4 != 0
+        str = str.ljust((str.length + 3) & ~3, "=")
+      end
+
+      Base64.urlsafe_decode64(str)
     end
   end
 end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -144,7 +144,7 @@ module Webpush
     end
 
     def trim_encode64(bin)
-      Base64.urlsafe_encode64(bin).delete('=')
+      Webpush.encode64(bin).delete('=')
     end
   end
 end

--- a/lib/webpush/vapid_key.rb
+++ b/lib/webpush/vapid_key.rb
@@ -30,7 +30,7 @@ module Webpush
     # Convenience
     # @return base64 urlsafe-encoded binary representaion of 32-byte VAPID private key
     def private_key
-      Base64.urlsafe_encode64(curve.private_key.to_s(2))
+      Webpush.encode64(curve.private_key.to_s(2))
     end
 
     def public_key=(key)
@@ -61,11 +61,11 @@ module Webpush
     private
 
     def to_big_num(key)
-      OpenSSL::BN.new(Base64.urlsafe_decode64(key), 2)
+      OpenSSL::BN.new(Webpush.decode64(key), 2)
     end
 
     def encode64(bin)
-      Base64.urlsafe_encode64(bin)
+      Webpush.encode64(bin)
     end
 
     def trim_encode64(bin)

--- a/spec/webpush/encryption_spec.rb
+++ b/spec/webpush/encryption_spec.rb
@@ -39,6 +39,24 @@ describe Webpush::Encryption do
       expect{Webpush::Encryption.encrypt("Hello world", p256dh, nil)}.to raise_error(ArgumentError)
     end
 
+    # Bug fix for https://github.com/zaru/webpush/issues/22
+    it 'handles unpadded base64 encoded subscription keys' do
+      unpadded_p256dh = "BK74n-ZA6kfMDEuCFbQH1Y5T33p39PvnzNeuD5LqTs8cF-uaQFUHn_v5kwV6dYIIL4nFabxghQNF_vlnAXX7OiU"
+      unpadded_auth = "1C1PBkJQsVwD9tkuLR1x5A"
+
+      payload = Webpush::Encryption.encrypt("Hello World", unpadded_p256dh, unpadded_auth)
+      encrypted = payload.fetch(:ciphertext)
+
+      decrypted_data = ECE.decrypt(encrypted,
+        key: payload.fetch(:shared_secret),
+        salt: payload.fetch(:salt),
+        server_public_key: payload.fetch(:server_public_key_bn),
+        user_public_key: decode64(pad64(unpadded_p256dh)),
+        auth: decode64(pad64(unpadded_auth)))
+
+      expect(decrypted_data).to eq("Hello World")
+    end
+
     def generate_ecdh_key
       group = "prime256v1"
       curve = OpenSSL::PKey::EC.new(group)
@@ -50,8 +68,15 @@ describe Webpush::Encryption do
       Base64.urlsafe_encode64(bytes)
     end
 
-    def decode64(bytes)
-      Base64.urlsafe_decode64(bytes)
+    def decode64(str)
+      Base64.urlsafe_decode64(str)
+    end
+
+    def pad64(str)
+      if !str.end_with?("=") && str.length % 4 != 0
+        str = str.ljust((str.length + 3) & ~3, "=")
+      end
+      str
     end
   end
 end


### PR DESCRIPTION
Fixes #22 

Backports the `Base64` decoding fix available in Ruby 2.3 to this gem, primarily with Ruby 2.2 in mind (as that's the Ruby version commonly associated with reports of this issue). 

I'm also opening for discussion the possibility of supporting Ruby 2.2. Adding the proper failing test also means running the Travis build against Ruby 2.2. I believe broadening coverage may encourage more folks to use this gem.