### PR TITLE
Minor fix in README: Close code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Webpush.payload_send(
     private_key: ENV['VAPID_PRIVATE_KEY']
   }
 )
+```
 
 ### With GCM api key
 
@@ -285,6 +286,7 @@ Webpush.payload_send(
   auth: "aW1hcmthcmFpa3V6ZQ==",
   api_key: "<GCM API KEY>"
 )
+```
 
 ### ServiceWorker sample
 


### PR DESCRIPTION
The code blocks in the readme file were not properly closed, which caused the formatting to be off.

Noticed this while researching for a way to send browser notifications to our users and therefore reading the documentation of this gem. Sounds interesting :)