### PR TITLE
fix code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ post "/push" do
     message: params[:message]
     endpoint: params[:subscription][:endpoint],
     p256dh: params[:subscription][:keys][:p256dh],
-    auth: params[:subscription][:keys][:p256dh],
+    auth: params[:subscription][:keys][:auth],
     vapid: {
       subject: "mailto:sender@example.com",
       public_key: ENV['VAPID_PUBLIC_KEY'],


### PR DESCRIPTION
In this case, I think `:auth` is preffered than `:p256dh` .