### PR TITLE
feat: improve response error codes

### DIFF
--- a/lib/webpush/errors.rb
+++ b/lib/webpush/errors.rb
@@ -3,7 +3,21 @@ module Webpush
 
   class ConfigurationError < Error; end
 
-  class ResponseError < Error; end
+  class ResponseError < Error;
+    attr_reader :response, :host
+
+    def initialize(response, host)
+      @response = response
+      @host = host
+      super "host: #{host}, #{@response.inspect}\nbody:\n#{@response.body}"
+    end
+  end
 
   class InvalidSubscription < ResponseError; end
+
+  class ExpiredSubscription < ResponseError; end
+
+  class PayloadTooLarge < ResponseError; end
+
+  class TooManyRequests < ResponseError; end
 end

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -56,6 +56,19 @@ describe Webpush do
       }
     end
 
+    it 'sets the error message to be the host + stringified response' do
+      stub_request(:post, expected_endpoint).
+        to_return(status: 401, body: "Oh snap", headers: {})
+
+      host = URI.parse(expected_endpoint).host
+
+      expect { subject }.to raise_error { |error|
+        expect(error.message).to eq(
+          "host: #{host}, #<Net::HTTPUnauthorized 401  readbody=true>\nbody:\nOh snap"
+        )
+      }
+    end
+
     it 'raises exception on error by default' do
       stub_request(:post, expected_endpoint).to_raise(StandardError)
 

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -5,6 +5,64 @@ describe Webpush do
     expect(Webpush::VERSION).not_to be nil
   end
 
+  shared_examples 'web push protocol standard error handling' do
+    it 'raises InvalidSubscription if and only if the combination of status code and message indicate an invalid subscription' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 410, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::InvalidSubscription)
+
+      stub_request(:post, expected_endpoint).
+          to_return(status: [400, "UnauthorizedRegistration"], body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::InvalidSubscription)
+
+      stub_request(:post, expected_endpoint).
+          to_return(status: 400, body: "", headers: {})
+      expect { subject }.not_to raise_error(Webpush::InvalidSubscription)
+    end
+
+    it 'raises ExpiredSubscription if the API returns a 404 Error' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 404, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::ExpiredSubscription)
+    end
+
+    it 'raises PayloadTooLarge if the API returns a 413 Error' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 413, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::PayloadTooLarge)
+    end
+
+    it 'raises TooManyRequests if the API returns a 429 Error' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 429, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::TooManyRequests)
+    end
+
+    it 'raises ResponseError for unsuccessful status code by default' do
+      stub_request(:post, expected_endpoint).
+        to_return(status: 401, body: "", headers: {})
+
+      expect { subject }.to raise_error(Webpush::ResponseError)
+    end
+
+    it 'supplies the original status code on the ResponseError' do
+      stub_request(:post, expected_endpoint).
+        to_return(status: 401, body: "Oh snap", headers: {})
+
+      expect { subject }.to raise_error { |error|
+        expect(error).to be_a(Webpush::ResponseError)
+        expect(error.response.code).to eq '401'
+        expect(error.response.body).to eq 'Oh snap'
+      }
+    end
+
+    it 'raises exception on error by default' do
+      stub_request(:post, expected_endpoint).to_raise(StandardError)
+
+      expect { subject }.to raise_error
+    end
+  end
+
   shared_examples 'request headers with VAPID' do
     let(:message) { JSON.generate({ body: 'body' }) }
     let(:p256dh) { 'BN4GvZtEZiZuqFxSKVZfSfluwKBD7UxHNBmWkfiZfCtgDE8Bwh-_MtLXbBxTBAWH9r7IPKL0lhdcaqtL1dfxU5E=' }
@@ -64,32 +122,7 @@ describe Webpush do
       expect(result.code).to eql('201')
     end
 
-    it 'raises InvalidSubscription if and only if the combination of status code and message indicate an invalid subscription' do
-      stub_request(:post, expected_endpoint).
-          to_return(status: 410, body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::InvalidSubscription)
-
-      stub_request(:post, expected_endpoint).
-          to_return(status: [400, "UnauthorizedRegistration"], body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::InvalidSubscription)
-
-      stub_request(:post, expected_endpoint).
-          to_return(status: 400, body: "", headers: {})
-      expect { subject }.not_to raise_error(Webpush::InvalidSubscription)
-    end
-
-    it 'raises ResponseError for unsuccessful status code by default' do
-      stub_request(:post, expected_endpoint).
-        to_return(status: 401, body: "", headers: {})
-
-      expect { subject }.to raise_error(Webpush::ResponseError)
-    end
-
-    it 'raises exception on error by default' do
-      stub_request(:post, expected_endpoint).to_raise(StandardError)
-
-      expect { subject }.to raise_error
-    end
+    include_examples 'web push protocol standard error handling'
 
     it 'message is optional' do
       expect(Webpush::Encryption).to_not receive(:encrypt)
@@ -187,61 +220,7 @@ describe Webpush do
       expect(result.code).to eql('201')
     end
 
-    it 'raises InvalidSubscription if and only if the combination of status code and message indicate an invalid subscription' do
-      stub_request(:post, expected_endpoint).
-          to_return(status: 410, body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::InvalidSubscription)
-
-      stub_request(:post, expected_endpoint).
-          to_return(status: [400, "UnauthorizedRegistration"], body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::InvalidSubscription)
-
-      stub_request(:post, expected_endpoint).
-          to_return(status: 400, body: "", headers: {})
-      expect { subject }.not_to raise_error(Webpush::InvalidSubscription)
-    end
-
-    it 'raises ExpiredSubscription if the API returns a 404 Error' do
-      stub_request(:post, expected_endpoint).
-          to_return(status: 404, body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::ExpiredSubscription)
-    end
-
-    it 'raises PayloadTooLarge if the API returns a 413 Error' do
-      stub_request(:post, expected_endpoint).
-          to_return(status: 413, body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::PayloadTooLarge)
-    end
-
-    it 'raises TooManyRequests if the API returns a 429 Error' do
-      stub_request(:post, expected_endpoint).
-          to_return(status: 429, body: "", headers: {})
-      expect { subject }.to raise_error(Webpush::TooManyRequests)
-    end
-
-    it 'raises ResponseError for unsuccessful status code by default' do
-      stub_request(:post, expected_endpoint).
-        to_return(status: 401, body: "", headers: {})
-
-      expect { subject }.to raise_error(Webpush::ResponseError)
-    end
-
-    it 'supplies the original status code on the ResponseError' do
-      stub_request(:post, expected_endpoint).
-        to_return(status: 401, body: "Oh snap", headers: {})
-
-      expect { subject }.to raise_error { |error|
-        expect(error).to be_a(Webpush::ResponseError)
-        expect(error.response.code).to eq '401'
-        expect(error.response.body).to eq 'Oh snap'
-      }
-    end
-
-    it 'raises exception on error by default' do
-      stub_request(:post, expected_endpoint).to_raise(StandardError)
-
-      expect { subject }.to raise_error
-    end
+    include_examples 'web push protocol standard error handling'
 
     it 'message and encryption keys are optional' do
       expect(Webpush::Encryption).to_not receive(:encrypt)


### PR DESCRIPTION
1) This library only currently supports specific 400/410 errors with `InvalidSubscription` 
2) For all other errors its difficult to determine what type of error occurred as `ResponseError` only provides a stringified version of the Net/HTTPResponse.

However the Web Push Protocol defines several possible responses; 

https://developers.google.com/web/fundamentals/engage-and-retain/push-notifications/web-push-protocol#response_from_push_service

This PR adds the following first-class error types;

- `ExpiredSubscription` (404)
- `PayloadTooLarge` (413)
- `TooManyRequests` (429)

It also adds the original Net/HTTPResponse error as an attribute on `ResponseError`. 