### PR TITLE
Add typ to JWT header fields

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -62,7 +62,7 @@ module Webpush
 
     def build_vapid_headers
       vapid_key = VapidKey.from_keys(vapid_public_key, vapid_private_key)
-      jwt = JWT.encode(jwt_payload, vapid_key.curve, 'ES256')
+      jwt = JWT.encode(jwt_payload, vapid_key.curve, 'ES256', jwt_header_fields)
       p256ecdsa = vapid_key.public_key_for_push_header
 
       {
@@ -99,6 +99,10 @@ module Webpush
         exp: Time.now.to_i + expiration,
         sub: subject,
       }
+    end
+
+    def jwt_header_fields
+      { 'typ' => 'JWT' }
     end
 
     def audience

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -41,11 +41,12 @@ describe Webpush::Request do
         exp: time.to_i + 24 * 60 * 60,
         sub: 'mailto:sender@example.com',
       }
+      jwt_header_fields = { 'typ' => 'JWT' }
 
       vapid_key = Webpush::VapidKey.from_keys(vapid_public_key, vapid_private_key)
       expect(Time).to receive(:now).and_return(time)
       expect(Webpush::VapidKey).to receive(:from_keys).with(vapid_public_key, vapid_private_key).and_return(vapid_key)
-      expect(JWT).to receive(:encode).with(jwt_payload, vapid_key.curve, 'ES256').and_return('jwt.encoded.payload')
+      expect(JWT).to receive(:encode).with(jwt_payload, vapid_key.curve, 'ES256', jwt_header_fields).and_return('jwt.encoded.payload')
 
       request = build_request(vapid: vapid_options)
       headers = request.build_vapid_headers

--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "hkdf", "~> 0.2"
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Resolve #42

typ has been removed from header fields in ruby-jwt 2.0 (https://github.com/jwt/ruby-jwt/pull/174). If typ is JWT not specified, Google's server does not do the appropriate processing, so let's add it.
