### PR TITLE
change jwt dependency version to fix WebPush error

### DIFF
--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "hkdf", "~> 0.2"
-  spec.add_dependency "jwt", "~> 2.0"
+  spec.add_dependency "jwt", "~> 1.5.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
When executing following command:
```
[1] pry(main)> Webpush.payload_send(message: "{ 'message': 'XDD'}", endpoint: "https://fcm.googleapis.com/fcm/send/...hidden text...", p256dh: "...hidden text...", auth: "...hidden text...", vapid: {subject: "...hidden text...", public_key: "...hidden text...", private_key: "...hidden text..."})
```
If using jwt-1.5.1 ~ jwt-1.5.6, it executes successfully:
```
#<Net::HTTPCreated 201 Created readbody=true>
```

If using jwt-1.5.0, shows the error:
```
Webpush::InvalidSubscription: #<Net::HTTPBadRequest 400 UnauthorizedRegistration readbody=true>
from /Users/luyan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/webpush-0c082169efc2/lib/webpush/request.rb:27:in `perform'
```

If using jwt-2.0.0.beta1, shows the error:
```
Webpush::ResponseError: host: fcm.googleapis.com, #<Net::HTTPInternalServerError 500 Internal Server Error readbody=true>
body:
<HTML>
<HEAD>
<TITLE>Internal Server Error</TITLE>
</HEAD>
<BODY BGCOLOR="#FFFFFF" TEXT="#000000">
<H1>Internal Server Error</H1>
<H2>Error 500</H2>
</BODY>
</HTML>
from /Users/luyan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/webpush-0c082169efc2/lib/webpush/request.rb:29:in `perform'
```