### PR TITLE
raise Webpush::TemporaryServerError on 502 & 503 responses

### DIFF
--- a/lib/webpush/errors.rb
+++ b/lib/webpush/errors.rb
@@ -20,4 +20,6 @@ module Webpush
   class PayloadTooLarge < ResponseError; end
 
   class TooManyRequests < ResponseError; end
+
+  class TemporaryServerError < ResponseError; end
 end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -31,6 +31,8 @@ module Webpush
         raise PayloadTooLarge.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPTooManyRequests) # 429, try again later!
         raise TooManyRequests.new(resp, uri.host)
+      elsif resp.is_a?(Net::HTTPBadGateway) || resp.is_a?(Net::HTTPServiceUnavailable) # 502, 503
+        raise TemporaryServerError.new(resp, uri.host)
       elsif !resp.is_a?(Net::HTTPSuccess)  # unknown/unhandled response error
         raise ResponseError.new(resp, uri.host)
       end

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -38,6 +38,18 @@ describe Webpush do
       expect { subject }.to raise_error(Webpush::TooManyRequests)
     end
 
+    it 'raises TemporaryServerError if the API returns a 502 Error' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 502, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::TemporaryServerError)
+    end
+
+    it 'raises TemporaryServerError if the API returns a 503 Error' do
+      stub_request(:post, expected_endpoint).
+          to_return(status: 503, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::TemporaryServerError)
+    end
+
     it 'raises ResponseError for unsuccessful status code by default' do
       stub_request(:post, expected_endpoint).
         to_return(status: 401, body: "", headers: {})


### PR DESCRIPTION
Every now and then I get a couple 502 and 503 responses for Chrome and Firefox, figured it would be nice to have a way to easily distinguish those responses from more serious errors.