### PR TITLE
Add Rake task to generate VAPID keys

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+import './lib/tasks/webpush.rake'

--- a/lib/tasks/webpush.rake
+++ b/lib/tasks/webpush.rake
@@ -1,0 +1,14 @@
+namespace :webpush do
+  desc 'Generate VAPID public/private key pair'
+  task :generate_keys do
+    require 'webpush'
+
+    Webpush.generate_key.tap do |keypair|
+      puts <<-KEYS
+Generated VAPID keypair:
+Public  -> #{keypair.public_key}
+Private -> #{keypair.private_key}
+      KEYS
+    end
+  end
+end

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -9,6 +9,7 @@ require 'webpush/errors'
 require 'webpush/vapid_key'
 require 'webpush/encryption'
 require 'webpush/request'
+require 'webpush/railtie' if defined?(Rails)
 
 module Webpush
   class << self

--- a/lib/webpush/railtie.rb
+++ b/lib/webpush/railtie.rb
@@ -1,0 +1,7 @@
+module Webpush
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load 'tasks/webpush.rake'
+    end
+  end
+end


### PR DESCRIPTION
Including a Railtie to expose the task to Rails

```
$ bundle exec rake webpush:generate_keys
Generated VAPID keypair:
Public  -> BHWm7c64jA-47VtiZ3kiNy9A5pG1PHIc03UNaUJgOM7ugZTKX-WCYFwkHtvFf1cXD6kG2SbVL_nwHLufyPACRCs=
Private -> YkHXD2KgKzNXtojIhC0Yu7TKukTuXHyArqSen8vbsAo=
```

Fixes #43