### PR TITLE
Add urgency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Webpush.payload_send(
   message: JSON.generate(message),
   p256dh: "BO/aG9nYXNkZmFkc2ZmZHNmYWRzZmFl...",
   auth: "aW1hcmthcmFpa3V6ZQ==",
-  ttl: 600 #optional, ttl in seconds, defaults to 2419200 (4 weeks),
+  ttl: 600, # optional, ttl in seconds, defaults to 2419200 (4 weeks)
+  urgency: 'normal' # optional, it can be very-low, low, normal, high, defaults to normal
 )
 ```
 

--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -26,6 +26,7 @@ module Webpush
     # @option vapid [String] :private_key the VAPID private key
     # @param options [Hash<Symbol,String>] additional options for the notification
     # @option options [#to_s] :ttl Time-to-live in seconds
+    # @option options [#to_s] :urgency Urgency can be very-low, low, normal, high
     def payload_send(message: "", endpoint:, p256dh: "", auth: "", vapid: {}, **options)
       subscription = {
         endpoint: endpoint,

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -46,6 +46,7 @@ module Webpush
       headers = {}
       headers["Content-Type"] = "application/octet-stream"
       headers["Ttl"]          = ttl
+      headers["Urgency"]      = urgency
 
       if @payload.has_key?(:server_public_key)
         headers["Content-Encoding"] = "aesgcm"
@@ -87,6 +88,10 @@ module Webpush
 
     def ttl
       @options.fetch(:ttl).to_s
+    end
+
+    def urgency
+      @options.fetch(:urgency).to_s
     end
 
     def dh_param
@@ -131,7 +136,8 @@ module Webpush
 
     def default_options
       {
-        ttl: 60*60*24*7*4 # 4 weeks
+        ttl: 60*60*24*7*4, # 4 weeks
+        urgency: 'normal'
       }
     end
 

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -6,6 +6,7 @@ describe Webpush::Request do
 
     it { expect(request.headers['Content-Type']).to eq('application/octet-stream') }
     it { expect(request.headers['Ttl']).to eq('2419200') }
+    it { expect(request.headers['Urgency']).to eq('normal') }
 
     describe 'from :message' do
       it 'inserts encryption headers for valid payload' do
@@ -29,6 +30,14 @@ describe Webpush::Request do
         request = build_request(ttl: 60 * 5)
 
         expect(request.headers['Ttl']).to eq('300')
+      end
+    end
+
+    describe 'from :urgency' do
+      it 'can override Urgency with :urgency option' do
+        request = build_request(urgency: 'high', vapid: vapid_options)
+
+        expect(request.headers['Urgency']).to eq('high')
       end
     end
   end

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -95,6 +95,7 @@ describe Webpush do
         'Crypto-Key'=>'dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE',
         'Encryption'=>'salt=WJeVM-RY-F9351SVxTFx_g',
         'Ttl'=>'2419200',
+        'Urgency'=>'normal',
         'User-Agent'=>'Ruby'
       }
     end
@@ -208,6 +209,7 @@ describe Webpush do
         'Crypto-Key'=>'dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE',
         'Encryption'=>'salt=WJeVM-RY-F9351SVxTFx_g',
         'Ttl'=>'2419200',
+        'Urgency'=>'normal',
         'User-Agent'=>'Ruby'
       }
     end


### PR DESCRIPTION
Add support for Urgency header as defined in RFC8030:
https://tools.ietf.org/html/rfc8030#section-5.3

It is useful in particular to wake up devices in power saving mode when a time sensitive message should be delivered.