### PR TITLE
Fix #55 and #51: raise the proper error based on the HTTP status code

### DIFF
--- a/lib/webpush/errors.rb
+++ b/lib/webpush/errors.rb
@@ -17,7 +17,12 @@ module Webpush
 
   class ExpiredSubscription < ResponseError; end
 
+  class Unauthorized < ResponseError; end
+
   class PayloadTooLarge < ResponseError; end
 
   class TooManyRequests < ResponseError; end
+
+  class PushServiceError < ResponseError; end
+
 end


### PR DESCRIPTION
See also http://autopush.readthedocs.io/en/latest/http.html#error-codes

Fixes:

- `InvalidSubscription` means that the endpoint does not exist (e.g. incorrect data), while `ExpiredSubscription` is very common and means that the endpoint used to be valid but is no longer usable (e.g. the user has unsubscribed, a subscription change, etc.)
- `Unauthorized` is distinct from `InvalidSubscription`, because the former may indicate a problem with VAPID, not with the endpoint itself, which can be valid

Improvements:

- Manage 5xx errors separately (`PushServiceError`): this can be useful to retry the delivery when a 5xx error occurs