### PR TITLE
Raise Webpush::Unauthorized on HTTP 403

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -30,7 +30,7 @@ module Webpush
         raise ExpiredSubscription.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPNotFound) # 404
         raise InvalidSubscription.new(resp, uri.host)
-      elsif resp.is_a?(Net::HTTPUnauthorized) || # 401, Mozilla autopush
+      elsif resp.is_a?(Net::HTTPUnauthorized) || resp.is_a?(Net::HTTPForbidden) || # 401, 403
         resp.is_a?(Net::HTTPBadRequest) && resp.message == "UnauthorizedRegistration" # 400, Google FCM
         raise Unauthorized.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPRequestEntityTooLarge) # 413

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -18,9 +18,13 @@ describe Webpush do
       expect { subject }.to raise_error(Webpush::ExpiredSubscription)
     end
 
-    it 'raises Unauthorized if the API returns a 401 Error or 400 with specific message' do
+    it 'raises Unauthorized if the API returns a 401 Error, a 403 Error or 400 with specific message' do
       stub_request(:post, expected_endpoint).
           to_return(status: 401, body: "", headers: {})
+      expect { subject }.to raise_error(Webpush::Unauthorized)
+
+      stub_request(:post, expected_endpoint).
+          to_return(status: 403, body: "", headers: {})
       expect { subject }.to raise_error(Webpush::Unauthorized)
 
       stub_request(:post, expected_endpoint).


### PR DESCRIPTION
If you use the wrong VAPID key pair (from another sender), FCM returns `403 MismatchSenderId`.

It makes sense to raise the same error for 401 and 403, since they are both related to VAPID.