### PR TITLE
Add PEM support to import / export keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ vapid_key = Webpush.generate_key
 # Save these in your application server settings
 vapid_key.public_key
 vapid_key.private_key
+
+# Or you can save in PEM format if you prefer
+vapid_key.to_pem
 ```
 
 ### Declaring manifest.json
@@ -277,6 +280,23 @@ Webpush.payload_send(
     subject: "mailto:sender@example.com"
     public_key: ENV['VAPID_PUBLIC_KEY'],
     private_key: ENV['VAPID_PRIVATE_KEY']
+  }
+)
+```
+
+### With VAPID in PEM format
+
+This library also supports the PEM format for the VAPID keys:
+
+```ruby
+Webpush.payload_send(
+  endpoint: "https://fcm.googleapis.com/gcm/send/eah7hak....",
+  message: "A message",
+  p256dh: "BO/aG9nYXNkZmFkc2ZmZHNmYWRzZmFl...",
+  auth: "aW1hcmthcmFpa3V6ZQ==",
+  vapid: {
+    subject: "mailto:sender@example.com"
+    pem: ENV['VAPID_KEYS']
   }
 )
 ```

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -70,7 +70,7 @@ module Webpush
     end
 
     def build_vapid_headers
-      vapid_key = VapidKey.from_keys(vapid_public_key, vapid_private_key)
+      vapid_key = vapid_pem ? VapidKey.from_pem(vapid_pem) : VapidKey.from_keys(vapid_public_key, vapid_private_key)
       jwt = JWT.encode(jwt_payload, vapid_key.curve, 'ES256', jwt_header_fields)
       p256ecdsa = vapid_key.public_key_for_push_header
 
@@ -136,6 +136,10 @@ module Webpush
 
     def vapid_private_key
       @vapid_options.fetch(:private_key, nil)
+    end
+
+    def vapid_pem
+      @vapid_options.fetch(:pem, nil)
     end
 
     def default_options

--- a/lib/webpush/vapid_key.rb
+++ b/lib/webpush/vapid_key.rb
@@ -14,6 +14,18 @@ module Webpush
       key
     end
 
+    # Create a VapidKey instance from pem encoded elliptic curve public and private keys
+    #
+    # @return [Webpush::VapidKey] a VapidKey instance for the given public and private keys
+    def self.from_pem(pem)
+      key = new
+      src = OpenSSL::PKey.read pem
+      key.curve.public_key = src.public_key
+      key.curve.private_key = src.private_key
+
+      key
+    end
+
     attr_reader :curve
 
     def initialize
@@ -62,6 +74,13 @@ module Webpush
       { public_key: public_key, private_key: private_key }
     end
     alias to_hash to_h
+
+    def to_pem
+      public_key = OpenSSL::PKey::EC.new curve
+      public_key.private_key = nil
+      
+      curve.to_pem + public_key.to_pem
+    end
 
     def inspect
       "#<#{self.class}:#{object_id.to_s(16)} #{to_h.map { |k, v| ":#{k}=#{v}" }.join(" ")}>"

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -69,6 +69,13 @@ describe Webpush::Request do
       expect(headers['Authorization']).to eq('WebPush jwt.encoded.payload')
       expect(headers['Crypto-Key']).to eq('p256ecdsa=' + vapid_public_key.delete('='))
     end
+
+    it 'supports PEM format' do
+      pem = Webpush::VapidKey.new.to_pem
+      expect(Webpush::VapidKey).to receive(:from_pem).with(pem).and_call_original
+      request = build_request(vapid: { subject: "mailto:sender@example.com", pem: pem })
+      request.build_vapid_headers
+    end
   end
 
   describe '#body' do

--- a/spec/webpush/vapid_key_spec.rb
+++ b/spec/webpush/vapid_key_spec.rb
@@ -35,6 +35,21 @@ describe Webpush::VapidKey do
     expect(hash[:private_key]).to eq(key.private_key)
   end
 
+  it "returns pem of public and private keys" do
+    key = Webpush::VapidKey.new
+    pem = key.to_pem
+
+    expect(pem).to include('-----BEGIN EC PRIVATE KEY-----')
+    expect(pem).to include('-----BEGIN PUBLIC KEY-----')
+  end
+
+  it "imports pem of public and private keys" do
+    pem = Webpush::VapidKey.new.to_pem
+    key = Webpush::VapidKey.from_pem pem
+    
+    expect(key.to_pem).to eq(pem)
+  end
+
   describe "self.from_keys" do
     it "returns an encoded public key" do
       key = Webpush::VapidKey.from_keys(vapid_public_key, vapid_private_key)


### PR DESCRIPTION
I have added two helper methods for importing / exporting keys in PEM format. It is useful for interoperability between different libraries and services that store or use the keys in different formats. For example it is useful in order to use this library if you already have existing keys in PEM format. It is also useful if you want to store your keys in PEM format, which is a de facto standard for keys.

```ruby
# example import (from PEM to base64)
vapid_key = Webpush::VapidKey.from_pem "YOUR PEM GOES HERE"
vapid_key.public_key
vapid_key.private_key

# example export (to PEM)
vapid_key = Webpush.generate_key
vapid_key.to_pem
```