### PR TITLE
Use resolv-replace

### DIFF
--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -4,6 +4,7 @@ require 'openssl'
 require 'base64'
 require 'hkdf'
 require 'net/http'
+require 'resolv-replace'
 require 'json'
 
 require 'webpush/version'


### PR DESCRIPTION
The current implementation uses a C-language level implementation for DNS resolution.
Because timeout is implemented with ruby thread, the DNS timeout cannot be interrupted.
So it takes more time than the timeout in cases where DNS cannot resolve.

In this PR, replacing the DNS resolver with an implementation of ruby allows for the correct timeout.


These are described in the Japanese reference manual.
https://docs.ruby-lang.org/ja/latest/class/Timeout.html
```
The timeout interrupt is provided by Thread. Implemented at the C language level, timeout is powerless for processing that Ruby threads cannot interrupt.
There aren't many of these at a practical level, but things like Socket won't cut in if DNS resolution takes too long (You must use resolv-replace).
You need to reimplement it in Ruby or be aware of Ruby threads on the C side.
```