### PR TITLE
switch to aes128gcm encoding

### DIFF
--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -61,15 +61,6 @@ module Webpush
       e_text + e_tag
     end
 
-    def create_info(type, context)
-      info = 'Content-Encoding: '
-      info += type
-      info += "\0"
-      info += 'P-256'
-      info += context
-      info
-    end
-
     def convert16bit(key)
       [key.to_s(16)].pack('H*')
     end

--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -23,50 +23,39 @@ module Webpush
 
       client_auth_token = Webpush.decode64(auth)
 
-      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: "Content-Encoding: auth\0").next_bytes(32)
+      info =  "WebPush: info\0" + convert16bit(client_public_key_bn) + convert16bit(server_public_key_bn)
+      keyinfo = "Content-Encoding: aes128gcm\0"
+      nonce_info = "Content-Encoding: nonce\0"
 
-      context = create_context(client_public_key_bn, server_public_key_bn)
+      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).next_bytes(32)
 
-      content_encryption_key_info = create_info('aesgcm', context)
-      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).next_bytes(16)
-
-      nonce_info = create_info('nonce', context)
+      content_encryption_key = HKDF.new(prk, salt: salt, info: keyinfo).next_bytes(16)
       nonce = HKDF.new(prk, salt: salt, info: nonce_info).next_bytes(12)
 
       ciphertext = encrypt_payload(message, content_encryption_key, nonce)
 
       {
-        ciphertext: ciphertext,
-        salt: salt,
-        server_public_key_bn: convert16bit(server_public_key_bn),
-        server_public_key: server_public_key_bn.to_s(2),
-        shared_secret: shared_secret
+          ciphertext: ciphertext,
+          salt: salt,
+          server_public_key_bn: convert16bit(server_public_key_bn),
+          server_public_key: server_public_key_bn.to_s(2),
+          shared_secret: shared_secret
       }
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 
-    def create_context(client_public_key, server_public_key)
-      c = convert16bit(client_public_key)
-      s = convert16bit(server_public_key)
-      context = "\0"
-      context += [c.bytesize].pack('n*')
-      context += c
-      context += [s.bytesize].pack('n*')
-      context += s
-      context
-    end
-
     def encrypt_payload(plaintext, content_encryption_key, nonce)
       cipher = OpenSSL::Cipher.new('aes-128-gcm')
       cipher.encrypt
       cipher.key = content_encryption_key
       cipher.iv = nonce
-      padding = cipher.update("\0\0")
-      text = cipher.update(plaintext)
 
-      e_text = padding + text + cipher.final
+      text = cipher.update(plaintext)
+      padding = cipher.update("\2\0")
+      e_text = text + padding + cipher.final
+
       e_tag = cipher.auth_tag
 
       e_text + e_tag

--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -39,7 +39,7 @@ module Webpush
       rs = ciphertext.bytesize
       raise ArgumentError, "encrypted payload is too big" if rs > 4096
 
-      aes128gcmheader = "#{salt}" + [rs].pack('N*') + [65].pack('c*') + serverkey16bn
+      aes128gcmheader = "#{salt}" + [rs].pack('N*') + [serverkey16bn.bytesize].pack('C*') + serverkey16bn
 
       aes128gcmheader + ciphertext
     end

--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -40,15 +40,8 @@ module Webpush
       raise ArgumentError, "encrypted payload is too big" if rs > 4096
 
       aes128gcmheader = "#{salt}" + [rs].pack('N*') + [65].pack('c*') + serverkey16bn
-      ciphertext_with_header = aes128gcmheader + ciphertext
 
-      {
-        ciphertext: ciphertext_with_header,
-        salt: salt,
-        server_public_key_bn: serverkey16bn,
-        server_public_key: server_public_key_bn.to_s(2),
-        shared_secret: shared_secret
-      }
+      aes128gcmheader + ciphertext
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -57,7 +57,7 @@ module Webpush
     def build_vapid_header
       # https://tools.ietf.org/id/draft-ietf-webpush-vapid-03.html
 
-      vapid_key = VapidKey.from_keys(vapid_public_key, vapid_private_key)
+      vapid_key = vapid_pem ? VapidKey.from_pem(vapid_pem) : VapidKey.from_keys(vapid_public_key, vapid_private_key)
       jwt = JWT.encode(jwt_payload, vapid_key.curve, 'ES256', jwt_header_fields)
       p256ecdsa = vapid_key.public_key_for_push_header
 

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -41,8 +41,11 @@ module Webpush
       headers['Content-Type'] = 'application/octet-stream'
       headers['Ttl']          = ttl
       headers['Urgency']      = urgency
-      headers['Content-Encoding'] = 'aes128gcm'
-      headers["Content-Length"] = @payload[:ciphertext].length.to_s
+
+      if @payload.key?(:server_public_key)
+        headers['Content-Encoding'] = 'aes128gcm'
+        headers["Content-Length"] = @payload[:ciphertext].length.to_s
+      end
 
       if api_key?
         headers['Authorization'] = "key=#{api_key}"

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -42,9 +42,9 @@ module Webpush
       headers['Ttl']          = ttl
       headers['Urgency']      = urgency
 
-      if @payload.key?(:ciphertext)
+      if @payload
         headers['Content-Encoding'] = 'aes128gcm'
-        headers["Content-Length"] = @payload[:ciphertext].length.to_s
+        headers["Content-Length"] = @payload.length.to_s
       end
 
       if api_key?
@@ -68,7 +68,7 @@ module Webpush
     end
 
     def body
-      @payload.fetch(:ciphertext, '')
+      @payload || ''
     end
 
     private
@@ -129,7 +129,7 @@ module Webpush
     end
 
     def build_payload(message, subscription)
-      return {} if message.nil? || message.empty?
+      return nil if message.nil? || message.empty?
 
       encrypt_payload(message, subscription.fetch(:keys))
     end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -52,7 +52,6 @@ module Webpush
       elsif vapid?
         vapid_headers = build_vapid_headers
         headers['Authorization'] = vapid_headers['Authorization']
-        headers['Crypto-Key'] = [headers['Crypto-Key'], vapid_headers['Crypto-Key']].compact.join(';')
       end
 
       headers
@@ -66,7 +65,6 @@ module Webpush
 
       {
         'Authorization' => 'WebPush ' + jwt,
-        'Crypto-Key' => 'p256ecdsa=' + p256ecdsa
       }
     end
 

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -85,14 +85,6 @@ module Webpush
       @options.fetch(:urgency).to_s
     end
 
-    def dh_param
-      trim_encode64(@payload.fetch(:server_public_key))
-    end
-
-    def salt_param
-      trim_encode64(@payload.fetch(:salt))
-    end
-
     def jwt_payload
       {
         aud: audience,

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -44,14 +44,10 @@ module Webpush
 
       if @payload.key?(:server_public_key)
         headers['Content-Encoding'] = 'aes128gcm'
-        headers['Crypto-Key'] = "dh=#{dh_param}"
       end
 
       if api_key?
         headers['Authorization'] = "key=#{api_key}"
-      elsif vapid?
-        vapid_headers = build_vapid_headers
-        headers['Authorization'] = vapid_headers['Authorization']
       end
 
       headers

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -43,9 +43,7 @@ module Webpush
       headers['Urgency']      = urgency
 
       if @payload.key?(:server_public_key)
-        headers['Content-Encoding'] = 'aesgcm'
-        headers['Encryption'] = "salt=#{salt_param}"
-        headers['Crypto-Key'] = "dh=#{dh_param}"
+        headers['Content-Encoding'] = 'aes128gcm'
       end
 
       if api_key?
@@ -53,7 +51,6 @@ module Webpush
       elsif vapid?
         vapid_headers = build_vapid_headers
         headers['Authorization'] = vapid_headers['Authorization']
-        headers['Crypto-Key'] = [headers['Crypto-Key'], vapid_headers['Crypto-Key']].compact.join(';')
       end
 
       headers
@@ -67,7 +64,6 @@ module Webpush
 
       {
         'Authorization' => 'WebPush ' + jwt,
-        'Crypto-Key' => 'p256ecdsa=' + p256ecdsa
       }
     end
 

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -44,6 +44,7 @@ module Webpush
 
       if @payload.key?(:server_public_key)
         headers['Content-Encoding'] = 'aes128gcm'
+        headers['Crypto-Key'] = "dh=#{dh_param}"
       end
 
       if api_key?
@@ -51,6 +52,7 @@ module Webpush
       elsif vapid?
         vapid_headers = build_vapid_headers
         headers['Authorization'] = vapid_headers['Authorization']
+        headers['Crypto-Key'] = [headers['Crypto-Key'], vapid_headers['Crypto-Key']].compact.join(';')
       end
 
       headers
@@ -64,6 +66,7 @@ module Webpush
 
       {
         'Authorization' => 'WebPush ' + jwt,
+        'Crypto-Key' => 'p256ecdsa=' + p256ecdsa
       }
     end
 

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -42,7 +42,7 @@ module Webpush
       headers['Ttl']          = ttl
       headers['Urgency']      = urgency
 
-      if @payload.key?(:server_public_key)
+      if @payload.key?(:ciphertext)
         headers['Content-Encoding'] = 'aes128gcm'
         headers["Content-Length"] = @payload[:ciphertext].length.to_s
       end

--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -48,6 +48,10 @@ module Webpush
 
       if api_key?
         headers['Authorization'] = "key=#{api_key}"
+      elsif vapid?
+        vapid_headers = build_vapid_headers
+        headers['Authorization'] = vapid_headers['Authorization']
+        headers['Crypto-Key'] = [headers['Crypto-Key'], vapid_headers['Crypto-Key']].compact.join(';')
       end
 
       headers

--- a/spec/webpush/encryption_spec.rb
+++ b/spec/webpush/encryption_spec.rb
@@ -35,7 +35,7 @@ describe Webpush::Encryption do
       decrypted_data = ECE.decrypt(ciphertext,
                                    key: shared_secret,
                                    salt: salt,
-                                   server_public_key: server_public_key_bn,
+                                   server_public_key: serverkey16bn,
                                    user_public_key: decode64(p256dh),
                                    auth: decode64(auth))
 

--- a/spec/webpush/encryption_spec.rb
+++ b/spec/webpush/encryption_spec.rb
@@ -3,21 +3,39 @@ require 'ece'
 
 describe Webpush::Encryption do
   describe '#encrypt' do
+    let(:curve) do
+      group = 'prime256v1'
+      OpenSSL::PKey::EC.new(group)
+    end
+
     let(:p256dh) do
-      encode64(generate_ecdh_key)
+      curve.generate_key
+      ecdh_key = curve.public_key.to_bn.to_s(2)
+      encode64(ecdh_key)
     end
 
     let(:auth) { encode64(Random.new.bytes(16)) }
 
     it 'returns ECDH encrypted cipher text, salt, and server_public_key' do
       payload = Webpush::Encryption.encrypt('Hello World', p256dh, auth)
+      salt = payload.byteslice(0, 16)
+      rs = payload.byteslice(16, 4).unpack("N*").first
+      idlen = payload.byteslice(20).unpack("C*").first
+      serverkey16bn = payload.byteslice(21, idlen)
+      ciphertext = payload.byteslice(21 + idlen + 1, rs)
 
-      encrypted = payload.fetch(:ciphertext)
+      expect(payload.bytesize).to eq(21 + idlen + rs)
 
-      decrypted_data = ECE.decrypt(encrypted,
-                                   key: payload.fetch(:shared_secret),
-                                   salt: payload.fetch(:salt),
-                                   server_public_key: payload.fetch(:server_public_key_bn),
+      group_name = 'prime256v1'
+      group = OpenSSL::PKey::EC::Group.new(group_name)
+      server_public_key_bn = OpenSSL::BN.new(serverkey16bn.unpack('H*').first, 16)
+      server_public_key = OpenSSL::PKey::EC::Point.new(group, server_public_key_bn)
+      shared_secret = curve.dh_compute_key(server_public_key)
+
+      decrypted_data = ECE.decrypt(ciphertext,
+                                   key: shared_secret,
+                                   salt: salt,
+                                   server_public_key: server_public_key_bn,
                                    user_public_key: decode64(p256dh),
                                    auth: decode64(auth))
 

--- a/spec/webpush/encryption_spec.rb
+++ b/spec/webpush/encryption_spec.rb
@@ -24,9 +24,9 @@ describe Webpush::Encryption do
       decrypted_data = Webpush::Encryption.decrypt(payload_vals[:ciphertext],
                                    key: payload_vals[:shared_secret],
                                    salt: payload_vals[:salt],
-                                   server_public_key: payload_vals[:serverkey16bn],
-                                   user_public_key: decode64(p256dh),
-                                   auth: decode64(auth))
+                                   server_public_key_bn: payload_vals[:server_public_key_bn],
+                                   p256dh: p256dh,
+                                   auth: auth)
 
       expect(decrypted_data).to eq('Hello World')
     end
@@ -58,9 +58,9 @@ describe Webpush::Encryption do
       decrypted_data = Webpush::Encryption.decrypt(payload_vals[:ciphertext],
                                    key: payload_vals[:shared_secret],
                                    salt: payload_vals[:salt],
-                                   server_public_key: payload_vals[:serverkey16bn],
-                                   user_public_key: decode64(pad64(unpadded_p256dh)),
-                                   auth: decode64(pad64(unpadded_auth)))
+                                   server_public_key_bn: payload_vals[:server_public_key_bn],
+                                   p256dh: unpadded_p256dh,
+                                   auth: unpadded_auth)
 
       expect(decrypted_data).to eq('Hello World')
     end
@@ -70,9 +70,9 @@ describe Webpush::Encryption do
       rs = payload.byteslice(16, 4).unpack("N*").first
       idlen = payload.byteslice(20).unpack("C*").first
       serverkey16bn = payload.byteslice(21, idlen)
-      ciphertext = payload.byteslice(20 + idlen + 1, rs)
+      ciphertext = payload.byteslice(21 + idlen, rs)
 
-      expect(payload.bytesize).to eq(20 + idlen + 1 + rs)
+      expect(payload.bytesize).to eq(21 + idlen + rs)
 
       group_name = 'prime256v1'
       group = OpenSSL::PKey::EC::Group.new(group_name)
@@ -84,7 +84,7 @@ describe Webpush::Encryption do
           ciphertext: ciphertext,
           shared_secret: shared_secret,
           salt: salt,
-          serverkey16bn: serverkey16bn
+          server_public_key_bn: server_public_key_bn
       }
     end
 

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -10,7 +10,7 @@ describe Webpush::Request do
 
     describe 'from :message' do
       it 'inserts encryption headers for valid payload' do
-        allow(Webpush::Encryption).to receive(:encrypt).and_return(ciphertext: 'encrypted', server_public_key: 'server_public_key', salt: 'salt')
+        allow(Webpush::Encryption).to receive(:encrypt).and_return('encrypted')
         request = build_request(message: 'Hello')
 
         expect(request.headers['Content-Encoding']).to eq('aes128gcm')
@@ -116,21 +116,15 @@ describe Webpush::Request do
   end
 
   describe '#body' do
-    it 'extracts :ciphertext from the :payload argument' do
-      allow(Webpush::Encryption).to receive(:encrypt).and_return(ciphertext: 'encrypted')
+    it 'is set to the payload if a message is provided' do
+      allow(Webpush::Encryption).to receive(:encrypt).and_return('encrypted')
 
       request = build_request(message: 'Hello')
 
       expect(request.body).to eq('encrypted')
     end
 
-    it 'is empty string when no :ciphertext' do
-      request = build_request(payload: {})
-
-      expect(request.body).to eq('')
-    end
-
-    it 'is empty string when no :payload' do
+    it 'is empty string when no message is provided' do
       request = build_request
 
       expect(request.body).to eq('')

--- a/spec/webpush/request_spec.rb
+++ b/spec/webpush/request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Webpush::Request do
   describe '#headers' do
-    let(:request) { build_request(vapid: vapid_options) }
+    let(:request) { build_request }
 
     it { expect(request.headers['Content-Type']).to eq('application/octet-stream') }
     it { expect(request.headers['Ttl']).to eq('2419200') }
@@ -65,7 +65,7 @@ describe Webpush::Request do
 
     describe 'from :ttl' do
       it 'can override Ttl with :ttl option with string' do
-        request = build_request(ttl: '300', vapid: vapid_options)
+        request = build_request(ttl: '300')
 
         expect(request.headers['Ttl']).to eq('300')
       end
@@ -79,7 +79,7 @@ describe Webpush::Request do
 
     describe 'from :urgency' do
       it 'can override Urgency with :urgency option' do
-        request = build_request(urgency: 'high', vapid: vapid_options)
+        request = build_request(urgency: 'high')
 
         expect(request.headers['Urgency']).to eq('high')
       end
@@ -101,7 +101,7 @@ describe Webpush::Request do
       expect(Webpush::VapidKey).to receive(:from_keys).with(vapid_public_key, vapid_private_key).and_return(vapid_key)
       expect(JWT).to receive(:encode).with(jwt_payload, vapid_key.curve, 'ES256', jwt_header_fields).and_return('jwt.encoded.payload')
 
-      request = build_request(vapid: vapid_options)
+      request = build_request
       header = request.build_vapid_header
 
       expect(header).to eq("vapid t=jwt.encoded.payload,k=#{vapid_public_key.delete('=')}")
@@ -119,7 +119,7 @@ describe Webpush::Request do
     it 'extracts :ciphertext from the :payload argument' do
       allow(Webpush::Encryption).to receive(:encrypt).and_return(ciphertext: 'encrypted')
 
-      request = build_request(message: 'Hello', vapid: vapid_options)
+      request = build_request(message: 'Hello')
 
       expect(request.body).to eq('encrypted')
     end

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -96,12 +96,8 @@ describe Webpush do
     let(:message) { JSON.generate(body: 'body') }
     let(:p256dh) { 'BN4GvZtEZiZuqFxSKVZfSfluwKBD7UxHNBmWkfiZfCtgDE8Bwh-_MtLXbBxTBAWH9r7IPKL0lhdcaqtL1dfxU5E=' }
     let(:auth) { 'Q2BoAjC09xH3ywDLNJr-dA==' }
-    let(:ciphertext) { "+\xB8\xDBT}\x13\xB6\xDD.\xF9\xB0\xA7\xC8\xD2\x80\xFD\x99#\xF7\xAC\x83\xA4\xDB,\x1F\xB5\xB9w\x85>\xF7\xADr" }
-    let(:salt) { "X\x97\x953\xE4X\xF8_w\xE7T\x95\xC51q\xFE" }
-    let(:server_public_key) { "\x04\b-RK9w\xDD$\x16lFz\xF9=\xB4~\xC6\x12k\xF3\xF40t\xA9\xC1\fR\xC3\x81\x80\xAC\f\x7F\xE4\xCC\x8E\xC2\x88 n\x8BB\xF1\x9C\x14\a\xFA\x8D\xC9\x80\xA1\xDDyU\\&c\x01\x88#\x118Ua" }
-    let(:shared_secret) { "\t\xA7&\x85\t\xC5m\b\xA8\xA7\xF8B{1\xADk\xE1y'm\xEDE\xEC\xDD\xEDj\xB3$s\xA9\xDA\xF0" }
-    let(:payload) { { ciphertext: ciphertext, salt: salt, server_public_key: server_public_key, shared_secret: shared_secret } }
-    let(:expected_body) { "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr" }
+    let(:payload) { "encrypted" }
+    let(:expected_body) { payload }
     let(:expected_headers) do
       {
         'Accept' => '*/*',
@@ -205,12 +201,8 @@ describe Webpush do
     let(:message) { JSON.generate(body: 'body') }
     let(:p256dh) { 'BN4GvZtEZiZuqFxSKVZfSfluwKBD7UxHNBmWkfiZfCtgDE8Bwh-_MtLXbBxTBAWH9r7IPKL0lhdcaqtL1dfxU5E=' }
     let(:auth) { 'Q2BoAjC09xH3ywDLNJr-dA==' }
-    let(:ciphertext) { "+\xB8\xDBT}\x13\xB6\xDD.\xF9\xB0\xA7\xC8\xD2\x80\xFD\x99#\xF7\xAC\x83\xA4\xDB,\x1F\xB5\xB9w\x85>\xF7\xADr" }
-    let(:salt) { "X\x97\x953\xE4X\xF8_w\xE7T\x95\xC51q\xFE" }
-    let(:server_public_key) { "\x04\b-RK9w\xDD$\x16lFz\xF9=\xB4~\xC6\x12k\xF3\xF40t\xA9\xC1\fR\xC3\x81\x80\xAC\f\x7F\xE4\xCC\x8E\xC2\x88 n\x8BB\xF1\x9C\x14\a\xFA\x8D\xC9\x80\xA1\xDDyU\\&c\x01\x88#\x118Ua" }
-    let(:shared_secret) { "\t\xA7&\x85\t\xC5m\b\xA8\xA7\xF8B{1\xADk\xE1y'm\xEDE\xEC\xDD\xEDj\xB3$s\xA9\xDA\xF0" }
-    let(:payload) { { ciphertext: ciphertext, salt: salt, server_public_key: server_public_key, shared_secret: shared_secret } }
-    let(:expected_body) { "+\xB8\xDBT}\x13\xB6\xDD.\xF9\xB0\xA7\xC8\xD2\x80\xFD\x99#\xF7\xAC\x83\xA4\xDB,\x1F\xB5\xB9w\x85>\xF7\xADr" }
+    let(:payload) { "encrypted" }
+    let(:expected_body) { payload }
     let(:expected_headers) do
       {
         'Accept' => '*/*',

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -106,22 +106,15 @@ describe Webpush do
       {
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Encoding' => 'aesgcm',
+        'Content-Encoding' => 'aes128gcm',
         'Content-Type' => 'application/octet-stream',
-        'Crypto-Key' => 'dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE',
-        'Encryption' => 'salt=WJeVM-RY-F9351SVxTFx_g',
         'Ttl' => '2419200',
         'Urgency' => 'normal',
         'User-Agent' => 'Ruby'
       }
     end
 
-    let(:vapid_headers) do
-      {
-        'Authorization' => 'WebPush jwt.encoded.payload',
-        'Crypto-Key' => 'p256ecdsa=' + vapid_public_key.delete('=')
-      }
-    end
+    let(:vapid_header) { "vapid t=jwt.encoded.payload,k=#{vapid_public_key.delete('=')}" }
 
     before do
       allow(Webpush::Encryption).to receive(:encrypt).and_return(payload)
@@ -141,8 +134,7 @@ describe Webpush do
     it 'calls the relevant service with the correct headers' do
       expect(Webpush::Encryption).to receive(:encrypt).and_return(payload)
 
-      expected_headers['Crypto-Key'] += ';' + vapid_headers['Crypto-Key']
-      expected_headers['Authorization'] = vapid_headers['Authorization']
+      expected_headers['Authorization'] = vapid_header
 
       stub_request(:post, expected_endpoint)
         .with(body: expected_body, headers: expected_headers)
@@ -223,10 +215,8 @@ describe Webpush do
       {
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Encoding' => 'aesgcm',
+        'Content-Encoding' => 'aes128gcm',
         'Content-Type' => 'application/octet-stream',
-        'Crypto-Key' => 'dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE',
-        'Encryption' => 'salt=WJeVM-RY-F9351SVxTFx_g',
         'Ttl' => '2419200',
         'Urgency' => 'normal',
         'User-Agent' => 'Ruby'
@@ -259,9 +249,7 @@ describe Webpush do
     it 'message and encryption keys are optional' do
       expect(Webpush::Encryption).to_not receive(:encrypt)
 
-      expected_headers.delete('Crypto-Key')
       expected_headers.delete('Content-Encoding')
-      expected_headers.delete('Encryption')
 
       stub_request(:post, expected_endpoint)
         .with(body: nil, headers: expected_headers)

--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
-  spec.add_development_dependency 'ece', '~> 0.2'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Me and @mplatov have been working out of this branch in the discussion of https://github.com/zaru/webpush/pull/75, so I'm making the pull request from here directly to avoid confusion as us and maybe others collaborate on the last remaining bit.

Everything is working, and has been tested with Chrome, Firefox, and Edge, and I've fixed up all but two of the tests: all that's needed is to be able to decrypt the payload correctly [here](https://github.com/mohamedhafez/webpush/blob/aes128gcm/spec/webpush/encryption_spec.rb#L25) and [here](https://github.com/mohamedhafez/webpush/blob/aes128gcm/spec/webpush/encryption_spec.rb#L59) in the tests. 

All the values I've extracted from the payload header in those two tests are correct, its just that I don't think the [ECE](https://github.com/randomlogin/ece) gem we're using to decode the payload supports aes128gcm encoding. It hasn't had a commit since 2016, we might be better off implementing our own decoding code instead just for this test, idk. Or maybe just testing against a hardcoded payload value we know is correct, like the one in the example from [the rfc spec](https://tools.ietf.org/html/rfc8188#page-7)?

In any case I'm way out of my comfort zone on this and have been working on this on top of 50 hour work weeks, and would really appreciate some help fixing up this last issue so we can get https://github.com/zaru/webpush/issues/60 finally fixed up, before push services stop accepting the deprecated encoding we are using and we find out the hard way!