### PR TITLE
set minimum ruby version is 2.2

### DIFF
--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'hkdf', '~> 0.2'
   spec.add_dependency 'jwt', '~> 2.0'


### PR DESCRIPTION
string as hash key are supported using the new notation in ruby 2.2 and later