### PR TITLE
Fix vapid key to_pem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ env:
     - CC_TEST_REPORTER_ID=155202524386dfebe0c3267a5c868b5417ff4cc2cde8ed301fb36b177d46a458
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/webpush/vapid_key.rb
+++ b/lib/webpush/vapid_key.rb
@@ -78,10 +78,15 @@ module Webpush
     alias to_hash to_h
 
     def to_pem
-      public_key = OpenSSL::PKey::EC.new curve
-      public_key.private_key = nil
+      private_key_to_pem + public_key_to_pem
+    end
 
-      curve.to_pem + public_key.to_pem
+    def private_key_to_pem
+      curve.to_pem
+    end
+
+    def public_key_to_pem
+      curve.public_to_pem
     end
 
     def inspect

--- a/spec/webpush/vapid_key_spec.rb
+++ b/spec/webpush/vapid_key_spec.rb
@@ -43,6 +43,35 @@ describe Webpush::VapidKey do
     expect(pem).to include('-----BEGIN PUBLIC KEY-----')
   end
 
+  it 'returns the correct public and private keys in pem format' do
+    public_key_base64 = 'BMA-wciFTkEq2waVGB2hg8cSyiRiMcsIvIYQb3LkLOmBheh3YC6NB2GtE9t6YgaXt428rp7bC9JjuPtAY9AQaR8='
+    private_key_base64 = '4MwLvN1Cpxe43AV9fa4BiS-SPp51gWlhv9c6bb_XSJ4='
+    key = Webpush::VapidKey.from_keys(public_key_base64, private_key_base64)
+    pem = key.to_pem
+    expected_pem = <<~PEM
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIODMC7zdQqcXuNwFfX2uAYkvkj6edYFpYb/XOm2/10ieoAoGCCqGSM49
+      AwEHoUQDQgAEwD7ByIVOQSrbBpUYHaGDxxLKJGIxywi8hhBvcuQs6YGF6HdgLo0H
+      Ya0T23piBpe3jbyuntsL0mO4+0Bj0BBpHw==
+      -----END EC PRIVATE KEY-----
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwD7ByIVOQSrbBpUYHaGDxxLKJGIx
+      ywi8hhBvcuQs6YGF6HdgLo0HYa0T23piBpe3jbyuntsL0mO4+0Bj0BBpHw==
+      -----END PUBLIC KEY-----
+    PEM
+    expect(pem).to eq(expected_pem)
+  end
+
+  it 'can return the private key in pem format' do
+    pem = Webpush::VapidKey.new.private_key_to_pem
+    expect(pem).to include('-----BEGIN EC PRIVATE KEY-----')
+  end
+
+  it 'can return the public key in pem format' do
+    pem = Webpush::VapidKey.new.public_key_to_pem
+    expect(pem).to include('-----BEGIN PUBLIC KEY-----')
+  end
+
   it 'imports pem of public and private keys' do
     pem = Webpush::VapidKey.new.to_pem
     key = Webpush::VapidKey.from_pem pem

--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -16,10 +16,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'hkdf', '~> 0.2'
   spec.add_dependency 'jwt', '~> 2.0'
+  spec.add_dependency 'openssl', '~> 2.2'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Due to upstream changes in the OpenSSL library, **Ruby 2.6.7, 2.7 and all later versions break the method `VapidKey#to_pem` of this library**.

You can read more here:
https://github.com/ruby/openssl/issues/437

Without this fix, in the new Ruby versions, the `to_pem` method would return the private key two times instead of the key pair (private key + public key).

Please merge this fix as soon as possible. Thank you!

