### PR TITLE
Fix wrong default value for VAPID subject

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -116,7 +116,7 @@ module Webpush
     end
 
     def subject
-      @vapid_options.fetch(:subject, 'sender@example.com')
+      @vapid_options.fetch(:subject, 'mailto:sender@example.com')
     end
 
     def vapid_public_key


### PR DESCRIPTION
The subject field must start with `mailto:` prefix.