### PR TITLE
Change VAPID expiration from 24h to 12h

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -112,7 +112,7 @@ module Webpush
     end
 
     def expiration
-      @vapid_options.fetch(:expiration, 24 * 60 * 60)
+      @vapid_options.fetch(:expiration, 12 * 60 * 60)
     end
 
     def subject


### PR DESCRIPTION
The default value of 24h is not a safe default value. 

Sometimes when you restart a server and the clock is wrong by a few seconds, it may result in notifications being rejected by Google Firebase.

Note that 24h is the limit for Firebase, so even a small bias can cause issues.

12h is a better default because it ensures the notification delivery even if the clock is not perfect. 

12h is the average between 24h (max) and 0 (min) and, given a random deviation in the clock, it maximizes the probability of successful notifications.