### PR TITLE
Treat 406 from Microsoft as 429

### DIFF
--- a/lib/webpush/request.rb
+++ b/lib/webpush/request.rb
@@ -175,7 +175,7 @@ module Webpush
         raise Unauthorized.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPRequestEntityTooLarge) # 413
         raise PayloadTooLarge.new(resp, uri.host)
-      elsif resp.is_a?(Net::HTTPTooManyRequests) # 429, try again later!
+      elsif resp.is_a?(Net::HTTPTooManyRequests) || resp.is_a?(Net::HTTPNotAcceptable) # 429, try again later! or 406 from Microsoft
         raise TooManyRequests.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPServerError) # 5xx
         raise PushServiceError.new(resp, uri.host)

--- a/spec/webpush_spec.rb
+++ b/spec/webpush_spec.rb
@@ -44,6 +44,12 @@ describe Webpush do
       expect { subject }.to raise_error(Webpush::TooManyRequests)
     end
 
+    it 'raises TooManyRequests if the API returns a 406 Error' do
+      stub_request(:post, expected_endpoint)
+        .to_return(status: 406, body: '', headers: {})
+      expect { subject }.to raise_error(Webpush::TooManyRequests)
+    end
+
     it 'raises PushServiceError if the API returns a 5xx Error' do
       stub_request(:post, expected_endpoint)
         .to_return(status: 500, body: '', headers: {})


### PR DESCRIPTION
According to [documentation](https://docs.microsoft.com/en-us/windows/apps/design/shell/tiles-and-notifications/push-request-response-headers#response-codes) Microsoft servers don't send 429, but sometimes they start sending 406, which basically means "try again later" as I see it.
I'd rather receive `TooManyRequests` error instead of `NotAcceptable`, 'cause it requires the same processing.
As far as I'm concerned, other services do not send 406, so it should be OK.