### PR TITLE
Update `hkdf` gem to 1.0.0

### DIFF
--- a/lib/webpush/encryption.rb
+++ b/lib/webpush/encryption.rb
@@ -27,11 +27,11 @@ module Webpush
       content_encryption_key_info = "Content-Encoding: aes128gcm\0"
       nonce_info = "Content-Encoding: nonce\0"
 
-      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).next_bytes(32)
+      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).read(32)
 
-      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).next_bytes(16)
+      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).read(16)
 
-      nonce = HKDF.new(prk, salt: salt, info: nonce_info).next_bytes(12)
+      nonce = HKDF.new(prk, salt: salt, info: nonce_info).read(12)
 
       ciphertext = encrypt_payload(message, content_encryption_key, nonce)
 

--- a/spec/webpush/encryption_spec.rb
+++ b/spec/webpush/encryption_spec.rb
@@ -67,10 +67,10 @@ describe Webpush::Encryption do
       content_encryption_key_info = "Content-Encoding: aes128gcm\0"
       nonce_info = "Content-Encoding: nonce\0"
 
-      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).next_bytes(32)
+      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).read(32)
 
-      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).next_bytes(16)
-      nonce = HKDF.new(prk, salt: salt, info: nonce_info).next_bytes(12)
+      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).read(16)
+      nonce = HKDF.new(prk, salt: salt, info: nonce_info).read(12)
 
       decrypt_ciphertext(ciphertext, content_encryption_key, nonce)
     end

--- a/webpush.gemspec
+++ b/webpush.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   
   spec.required_ruby_version = '>= 2.2'
 
-  spec.add_dependency 'hkdf', '~> 0.2'
+  spec.add_dependency 'hkdf', '~> 1.0'
   spec.add_dependency 'jwt', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17.3'


### PR DESCRIPTION
The previously used version (0.2.0) is 10 years old at this point.